### PR TITLE
Fix for #8: make forward/backward compatible with tf-1.0.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The end goal is to provide utilities to convert other datasets, report accuracie
 
 This code requires:
 
-1. Tensorflow ```r0.12``` or later version.
+1. Tensorflow ```r1.0``` or later version.
 
 2. Custom [tensorflow/models](https://github.com/tensorflow/models) repository, which might be [merged](https://github.com/tensorflow/models/pull/684) in a future.
 

--- a/tf_image_segmentation/models/fcn_16s.py
+++ b/tf_image_segmentation/models/fcn_16s.py
@@ -3,6 +3,9 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -83,12 +86,20 @@ def FCN_16s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                  last_layer_logits_shape[0],
-                                                                  last_layer_logits_shape[1] * 2,
-                                                                  last_layer_logits_shape[2] * 2,
-                                                                  last_layer_logits_shape[3]
-                                                                 ])
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                      last_layer_logits_shape[0],
+                                                                      last_layer_logits_shape[1] * 2,
+                                                                      last_layer_logits_shape[2] * 2,
+                                                                      last_layer_logits_shape[3]
+                                                                     ])
+            else:
+                last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
+                                                                      last_layer_logits_shape[0],
+                                                                      last_layer_logits_shape[1] * 2,
+                                                                      last_layer_logits_shape[2] * 2,
+                                                                      last_layer_logits_shape[3]
+                                                                     ])
 
             # Perform the upsampling
             last_layer_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(last_layer_logits,
@@ -103,13 +114,22 @@ def FCN_16s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            pool4_logits = slim.conv2d(pool4_features,
-                                       number_of_classes,
-                                       [1, 1],
-                                       activation_fn=None,
-                                       normalizer_fn=None,
-                                       weights_initializer=tf.zeros_initializer,
-                                       scope='pool4_fc')
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                pool4_logits = slim.conv2d(pool4_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer(),
+                                           scope='pool4_fc')
+            else:
+                pool4_logits = slim.conv2d(pool4_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer,
+                                           scope='pool4_fc')
 
             fused_last_layer_and_pool4_logits = pool4_logits + last_layer_upsampled_by_factor_2_logits
 
@@ -117,12 +137,21 @@ def FCN_16s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.pack([
-                                                                          fused_last_layer_and_pool4_logits_shape[0],
-                                                                          fused_last_layer_and_pool4_logits_shape[1] * 16,
-                                                                          fused_last_layer_and_pool4_logits_shape[2] * 16,
-                                                                          fused_last_layer_and_pool4_logits_shape[3]
-                                                                         ])
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.stack([
+                                                                              fused_last_layer_and_pool4_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_shape[1] * 16,
+                                                                              fused_last_layer_and_pool4_logits_shape[2] * 16,
+                                                                              fused_last_layer_and_pool4_logits_shape[3]
+                                                                             ])
+            else:
+                fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.pack([
+                                                                              fused_last_layer_and_pool4_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_shape[1] * 16,
+                                                                              fused_last_layer_and_pool4_logits_shape[2] * 16,
+                                                                              fused_last_layer_and_pool4_logits_shape[3]
+                                                                             ])
+                
 
             # Perform the upsampling
             fused_last_layer_and_pool4_upsampled_by_factor_16_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits,

--- a/tf_image_segmentation/models/fcn_16s.py
+++ b/tf_image_segmentation/models/fcn_16s.py
@@ -3,9 +3,6 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/models/fcn_16s.py
+++ b/tf_image_segmentation/models/fcn_16s.py
@@ -86,20 +86,12 @@ def FCN_16s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
-                                                                      last_layer_logits_shape[0],
-                                                                      last_layer_logits_shape[1] * 2,
-                                                                      last_layer_logits_shape[2] * 2,
-                                                                      last_layer_logits_shape[3]
-                                                                     ])
-            else:
-                last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                      last_layer_logits_shape[0],
-                                                                      last_layer_logits_shape[1] * 2,
-                                                                      last_layer_logits_shape[2] * 2,
-                                                                      last_layer_logits_shape[3]
-                                                                     ])
+            last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                  last_layer_logits_shape[0],
+                                                                  last_layer_logits_shape[1] * 2,
+                                                                  last_layer_logits_shape[2] * 2,
+                                                                  last_layer_logits_shape[3]
+                                                                 ])
 
             # Perform the upsampling
             last_layer_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(last_layer_logits,
@@ -114,22 +106,13 @@ def FCN_16s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                pool4_logits = slim.conv2d(pool4_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer(),
-                                           scope='pool4_fc')
-            else:
-                pool4_logits = slim.conv2d(pool4_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer,
-                                           scope='pool4_fc')
+            pool4_logits = slim.conv2d(pool4_features,
+                                       number_of_classes,
+                                       [1, 1],
+                                       activation_fn=None,
+                                       normalizer_fn=None,
+                                       weights_initializer=tf.zeros_initializer(),
+                                       scope='pool4_fc')
 
             fused_last_layer_and_pool4_logits = pool4_logits + last_layer_upsampled_by_factor_2_logits
 
@@ -137,21 +120,12 @@ def FCN_16s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.stack([
-                                                                              fused_last_layer_and_pool4_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_shape[1] * 16,
-                                                                              fused_last_layer_and_pool4_logits_shape[2] * 16,
-                                                                              fused_last_layer_and_pool4_logits_shape[3]
-                                                                             ])
-            else:
-                fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.pack([
-                                                                              fused_last_layer_and_pool4_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_shape[1] * 16,
-                                                                              fused_last_layer_and_pool4_logits_shape[2] * 16,
-                                                                              fused_last_layer_and_pool4_logits_shape[3]
-                                                                             ])
-                
+            fused_last_layer_and_pool4_upsampled_by_factor_16_logits_shape = tf.stack([
+                                                                          fused_last_layer_and_pool4_logits_shape[0],
+                                                                          fused_last_layer_and_pool4_logits_shape[1] * 16,
+                                                                          fused_last_layer_and_pool4_logits_shape[2] * 16,
+                                                                          fused_last_layer_and_pool4_logits_shape[3]
+                                                                         ])
 
             # Perform the upsampling
             fused_last_layer_and_pool4_upsampled_by_factor_16_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits,

--- a/tf_image_segmentation/models/fcn_32s.py
+++ b/tf_image_segmentation/models/fcn_32s.py
@@ -117,20 +117,12 @@ def FCN_32s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        if version.parse(tf.__version__) >= version.parse('1.0.0'):
-            upsampled_logits_shape = tf.stack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
-        else:
-            upsampled_logits_shape = tf.pack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
+        upsampled_logits_shape = tf.stack([
+                                          downsampled_logits_shape[0],
+                                          downsampled_logits_shape[1] * upsample_factor,
+                                          downsampled_logits_shape[2] * upsample_factor,
+                                          downsampled_logits_shape[3]
+                                         ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/fcn_32s.py
+++ b/tf_image_segmentation/models/fcn_32s.py
@@ -3,9 +3,6 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/models/fcn_32s.py
+++ b/tf_image_segmentation/models/fcn_32s.py
@@ -3,6 +3,9 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -114,12 +117,20 @@ def FCN_32s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        upsampled_logits_shape = tf.pack([
-                                          downsampled_logits_shape[0],
-                                          downsampled_logits_shape[1] * upsample_factor,
-                                          downsampled_logits_shape[2] * upsample_factor,
-                                          downsampled_logits_shape[3]
-                                         ])
+        if version.parse(tf.__version__) >= version.parse('1.0.0'):
+            upsampled_logits_shape = tf.stack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
+        else:
+            upsampled_logits_shape = tf.pack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/fcn_8s.py
+++ b/tf_image_segmentation/models/fcn_8s.py
@@ -3,9 +3,6 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/models/fcn_8s.py
+++ b/tf_image_segmentation/models/fcn_8s.py
@@ -3,6 +3,9 @@ import tensorflow as tf
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -83,12 +86,20 @@ def FCN_8s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                  last_layer_logits_shape[0],
-                                                                  last_layer_logits_shape[1] * 2,
-                                                                  last_layer_logits_shape[2] * 2,
-                                                                  last_layer_logits_shape[3]
-                                                                 ])
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                      last_layer_logits_shape[0],
+                                                                      last_layer_logits_shape[1] * 2,
+                                                                      last_layer_logits_shape[2] * 2,
+                                                                      last_layer_logits_shape[3]
+                                                                     ])
+            else:
+                last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
+                                                                      last_layer_logits_shape[0],
+                                                                      last_layer_logits_shape[1] * 2,
+                                                                      last_layer_logits_shape[2] * 2,
+                                                                      last_layer_logits_shape[3]
+                                                                     ])
 
             # Perform the upsampling
             last_layer_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(last_layer_logits,
@@ -105,13 +116,22 @@ def FCN_8s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            pool4_logits = slim.conv2d(pool4_features,
-                                       number_of_classes,
-                                       [1, 1],
-                                       activation_fn=None,
-                                       normalizer_fn=None,
-                                       weights_initializer=tf.zeros_initializer,
-                                       scope='pool4_fc')
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                pool4_logits = slim.conv2d(pool4_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer(),
+                                           scope='pool4_fc')
+            else:
+                pool4_logits = slim.conv2d(pool4_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer,
+                                           scope='pool4_fc')
 
             fused_last_layer_and_pool4_logits = pool4_logits + last_layer_upsampled_by_factor_2_logits
 
@@ -121,12 +141,20 @@ def FCN_8s(image_batch_tensor,
             
 
             # Calculate the ouput size of the upsampled tensor
-            fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                          fused_last_layer_and_pool4_logits_shape[0],
-                                                                          fused_last_layer_and_pool4_logits_shape[1] * 2,
-                                                                          fused_last_layer_and_pool4_logits_shape[2] * 2,
-                                                                          fused_last_layer_and_pool4_logits_shape[3]
-                                                                         ])
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                              fused_last_layer_and_pool4_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_shape[1] * 2,
+                                                                              fused_last_layer_and_pool4_logits_shape[2] * 2,
+                                                                              fused_last_layer_and_pool4_logits_shape[3]
+                                                                             ])
+            else:
+                fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.pack([
+                                                                              fused_last_layer_and_pool4_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_shape[1] * 2,
+                                                                              fused_last_layer_and_pool4_logits_shape[2] * 2,
+                                                                              fused_last_layer_and_pool4_logits_shape[3]
+                                                                             ])
 
             # Perform the upsampling
             fused_last_layer_and_pool4_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits,
@@ -142,13 +170,22 @@ def FCN_8s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            pool3_logits = slim.conv2d(pool3_features,
-                                       number_of_classes,
-                                       [1, 1],
-                                       activation_fn=None,
-                                       normalizer_fn=None,
-                                       weights_initializer=tf.zeros_initializer,
-                                       scope='pool3_fc')
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                pool3_logits = slim.conv2d(pool3_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer(),
+                                           scope='pool3_fc')
+            else:
+                pool3_logits = slim.conv2d(pool3_features,
+                                           number_of_classes,
+                                           [1, 1],
+                                           activation_fn=None,
+                                           normalizer_fn=None,
+                                           weights_initializer=tf.zeros_initializer,
+                                           scope='pool3_fc')
             
             
             fused_last_layer_and_pool4_logits_and_pool_3_logits = pool3_logits + \
@@ -159,12 +196,20 @@ def FCN_8s(image_batch_tensor,
             
             
             # Calculate the ouput size of the upsampled tensor
-            fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.pack([
-                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
-                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
-                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
-                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
-                                                                         ])
+            if version.parse(tf.__version__) >= version.parse('1.0.0'):
+                fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.stack([
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
+                                                                             ])
+            else:
+                fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.pack([
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
+                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
+                                                                             ])
 
             # Perform the upsampling
             fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits_and_pool_3_logits,

--- a/tf_image_segmentation/models/fcn_8s.py
+++ b/tf_image_segmentation/models/fcn_8s.py
@@ -86,20 +86,12 @@ def FCN_8s(image_batch_tensor,
 
 
             # Calculate the ouput size of the upsampled tensor
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
-                                                                      last_layer_logits_shape[0],
-                                                                      last_layer_logits_shape[1] * 2,
-                                                                      last_layer_logits_shape[2] * 2,
-                                                                      last_layer_logits_shape[3]
-                                                                     ])
-            else:
-                last_layer_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                      last_layer_logits_shape[0],
-                                                                      last_layer_logits_shape[1] * 2,
-                                                                      last_layer_logits_shape[2] * 2,
-                                                                      last_layer_logits_shape[3]
-                                                                     ])
+            last_layer_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                  last_layer_logits_shape[0],
+                                                                  last_layer_logits_shape[1] * 2,
+                                                                  last_layer_logits_shape[2] * 2,
+                                                                  last_layer_logits_shape[3]
+                                                                 ])
 
             # Perform the upsampling
             last_layer_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(last_layer_logits,
@@ -116,22 +108,13 @@ def FCN_8s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                pool4_logits = slim.conv2d(pool4_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer(),
-                                           scope='pool4_fc')
-            else:
-                pool4_logits = slim.conv2d(pool4_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer,
-                                           scope='pool4_fc')
+            pool4_logits = slim.conv2d(pool4_features,
+                                       number_of_classes,
+                                       [1, 1],
+                                       activation_fn=None,
+                                       normalizer_fn=None,
+                                       weights_initializer=tf.zeros_initializer(),
+                                       scope='pool4_fc')
 
             fused_last_layer_and_pool4_logits = pool4_logits + last_layer_upsampled_by_factor_2_logits
 
@@ -141,20 +124,12 @@ def FCN_8s(image_batch_tensor,
             
 
             # Calculate the ouput size of the upsampled tensor
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.stack([
-                                                                              fused_last_layer_and_pool4_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_shape[1] * 2,
-                                                                              fused_last_layer_and_pool4_logits_shape[2] * 2,
-                                                                              fused_last_layer_and_pool4_logits_shape[3]
-                                                                             ])
-            else:
-                fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.pack([
-                                                                              fused_last_layer_and_pool4_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_shape[1] * 2,
-                                                                              fused_last_layer_and_pool4_logits_shape[2] * 2,
-                                                                              fused_last_layer_and_pool4_logits_shape[3]
-                                                                             ])
+            fused_last_layer_and_pool4_upsampled_by_factor_2_logits_shape = tf.stack([
+                                                                          fused_last_layer_and_pool4_logits_shape[0],
+                                                                          fused_last_layer_and_pool4_logits_shape[1] * 2,
+                                                                          fused_last_layer_and_pool4_logits_shape[2] * 2,
+                                                                          fused_last_layer_and_pool4_logits_shape[3]
+                                                                         ])
 
             # Perform the upsampling
             fused_last_layer_and_pool4_upsampled_by_factor_2_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits,
@@ -170,22 +145,13 @@ def FCN_8s(image_batch_tensor,
             # We zero initialize the weights to start training with the same
             # accuracy that we ended training FCN-32s
 
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                pool3_logits = slim.conv2d(pool3_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer(),
-                                           scope='pool3_fc')
-            else:
-                pool3_logits = slim.conv2d(pool3_features,
-                                           number_of_classes,
-                                           [1, 1],
-                                           activation_fn=None,
-                                           normalizer_fn=None,
-                                           weights_initializer=tf.zeros_initializer,
-                                           scope='pool3_fc')
+            pool3_logits = slim.conv2d(pool3_features,
+                                       number_of_classes,
+                                       [1, 1],
+                                       activation_fn=None,
+                                       normalizer_fn=None,
+                                       weights_initializer=tf.zeros_initializer(),
+                                       scope='pool3_fc')
             
             
             fused_last_layer_and_pool4_logits_and_pool_3_logits = pool3_logits + \
@@ -196,20 +162,12 @@ def FCN_8s(image_batch_tensor,
             
             
             # Calculate the ouput size of the upsampled tensor
-            if version.parse(tf.__version__) >= version.parse('1.0.0'):
-                fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.stack([
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
-                                                                             ])
-            else:
-                fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.pack([
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
-                                                                              fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
-                                                                             ])
+            fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits_shape = tf.stack([
+                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[0],
+                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[1] * 8,
+                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[2] * 8,
+                                                                          fused_last_layer_and_pool4_logits_and_pool_3_logits_shape[3]
+                                                                         ])
 
             # Perform the upsampling
             fused_last_layer_and_pool4_logits_and_pool_3_upsampled_by_factor_8_logits = tf.nn.conv2d_transpose(fused_last_layer_and_pool4_logits_and_pool_3_logits,

--- a/tf_image_segmentation/models/resnet_v1_101_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_101_16s.py
@@ -3,6 +3,9 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -116,12 +119,20 @@ def resnet_v1_101_16s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        upsampled_logits_shape = tf.pack([
-                                          downsampled_logits_shape[0],
-                                          downsampled_logits_shape[1] * upsample_factor,
-                                          downsampled_logits_shape[2] * upsample_factor,
-                                          downsampled_logits_shape[3]
-                                         ])
+        if version.parse(tf.__version__) >= version.parse('1.0.0'):
+            upsampled_logits_shape = tf.stack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
+        else:
+            upsampled_logits_shape = tf.pack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_101_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_101_16s.py
@@ -119,20 +119,12 @@ def resnet_v1_101_16s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        if version.parse(tf.__version__) >= version.parse('1.0.0'):
-            upsampled_logits_shape = tf.stack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
-        else:
-            upsampled_logits_shape = tf.pack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
+        upsampled_logits_shape = tf.stack([
+                                          downsampled_logits_shape[0],
+                                          downsampled_logits_shape[1] * upsample_factor,
+                                          downsampled_logits_shape[2] * upsample_factor,
+                                          downsampled_logits_shape[3]
+                                         ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_101_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_101_16s.py
@@ -3,9 +3,6 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/models/resnet_v1_101_8s.py
+++ b/tf_image_segmentation/models/resnet_v1_101_8s.py
@@ -116,12 +116,12 @@ def resnet_v1_101_8s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        upsampled_logits_shape = tf.pack([
-                                          downsampled_logits_shape[0],
-                                          downsampled_logits_shape[1] * upsample_factor,
-                                          downsampled_logits_shape[2] * upsample_factor,
-                                          downsampled_logits_shape[3]
-                                         ])
+        upsampled_logits_shape = tf.stack([
+                                           downsampled_logits_shape[0],
+                                           downsampled_logits_shape[1] * upsample_factor,
+                                           downsampled_logits_shape[2] * upsample_factor,
+                                           downsampled_logits_shape[3]
+                                          ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_50_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_16s.py
@@ -119,20 +119,12 @@ def resnet_v1_50_16s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        if version.parse(tf.__version__) >= version.parse('1.0.0'):
-            upsampled_logits_shape = tf.stack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
-        else:
-            upsampled_logits_shape = tf.pack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
+        upsampled_logits_shape = tf.stack([
+                                          downsampled_logits_shape[0],
+                                          downsampled_logits_shape[1] * upsample_factor,
+                                          downsampled_logits_shape[2] * upsample_factor,
+                                          downsampled_logits_shape[3]
+                                         ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_50_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_16s.py
@@ -3,6 +3,9 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -116,12 +119,20 @@ def resnet_v1_50_16s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        upsampled_logits_shape = tf.pack([
-                                          downsampled_logits_shape[0],
-                                          downsampled_logits_shape[1] * upsample_factor,
-                                          downsampled_logits_shape[2] * upsample_factor,
-                                          downsampled_logits_shape[3]
-                                         ])
+        if version.parse(tf.__version__) >= version.parse('1.0.0'):
+            upsampled_logits_shape = tf.stack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
+        else:
+            upsampled_logits_shape = tf.pack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_50_16s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_16s.py
@@ -3,9 +3,6 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/models/resnet_v1_50_8s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_8s.py
@@ -3,6 +3,9 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 slim = tf.contrib.slim
 
 # Mean values for VGG-16
@@ -116,12 +119,20 @@ def resnet_v1_50_8s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        upsampled_logits_shape = tf.pack([
-                                          downsampled_logits_shape[0],
-                                          downsampled_logits_shape[1] * upsample_factor,
-                                          downsampled_logits_shape[2] * upsample_factor,
-                                          downsampled_logits_shape[3]
-                                         ])
+        if version.parse(tf.__version__) >= version.parse('1.0.0'):
+            upsampled_logits_shape = tf.stack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
+        else:
+            upsampled_logits_shape = tf.pack([
+                                              downsampled_logits_shape[0],
+                                              downsampled_logits_shape[1] * upsample_factor,
+                                              downsampled_logits_shape[2] * upsample_factor,
+                                              downsampled_logits_shape[3]
+                                             ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_50_8s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_8s.py
@@ -119,20 +119,12 @@ def resnet_v1_50_8s(image_batch_tensor,
         downsampled_logits_shape = tf.shape(logits)
 
         # Calculate the ouput size of the upsampled tensor
-        if version.parse(tf.__version__) >= version.parse('1.0.0'):
-            upsampled_logits_shape = tf.stack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
-        else:
-            upsampled_logits_shape = tf.pack([
-                                              downsampled_logits_shape[0],
-                                              downsampled_logits_shape[1] * upsample_factor,
-                                              downsampled_logits_shape[2] * upsample_factor,
-                                              downsampled_logits_shape[3]
-                                             ])
+        upsampled_logits_shape = tf.stack([
+                                          downsampled_logits_shape[0],
+                                          downsampled_logits_shape[1] * upsample_factor,
+                                          downsampled_logits_shape[2] * upsample_factor,
+                                          downsampled_logits_shape[3]
+                                         ])
 
         # Perform the upsampling
         upsampled_logits = tf.nn.conv2d_transpose(logits,

--- a/tf_image_segmentation/models/resnet_v1_50_8s.py
+++ b/tf_image_segmentation/models/resnet_v1_50_8s.py
@@ -3,9 +3,6 @@ from nets import resnet_v1
 from preprocessing import vgg_preprocessing
 from ..utils.upsampling import bilinear_upsample_weights
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 slim = tf.contrib.slim
 
 # Mean values for VGG-16

--- a/tf_image_segmentation/utils/inference.py
+++ b/tf_image_segmentation/utils/inference.py
@@ -61,10 +61,7 @@ def adapt_network_for_any_size_input(network_definition, multiple):
         
         # TODO: check if it works with logits, maybe there is no need
         # to do argmax
-        if version.parse(tf.__version__) >= version.parse('1.0.0'):
-            pred = tf.argmax(upsampled_logits_batch, axis=3)
-        else:
-            pred = tf.argmax(upsampled_logits_batch, dimension=3)
+        pred = tf.argmax(upsampled_logits_batch, axis=3)
 
         temp_pred = tf.expand_dims(pred, 3)
 

--- a/tf_image_segmentation/utils/inference.py
+++ b/tf_image_segmentation/utils/inference.py
@@ -1,5 +1,8 @@
 import tensorflow as tf
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 def adapt_network_for_any_size_input(network_definition, multiple):
     """Returns an updated function for network definition that supports input of any size.
     The function creates a new function that is an original function wrapped with
@@ -58,7 +61,10 @@ def adapt_network_for_any_size_input(network_definition, multiple):
         
         # TODO: check if it works with logits, maybe there is no need
         # to do argmax
-        pred = tf.argmax(upsampled_logits_batch, dimension=3)
+        if version.parse(tf.__version__) >= version.parse('1.0.0'):
+            pred = tf.argmax(upsampled_logits_batch, axis=3)
+        else:
+            pred = tf.argmax(upsampled_logits_batch, dimension=3)
 
         temp_pred = tf.expand_dims(pred, 3)
 

--- a/tf_image_segmentation/utils/inference.py
+++ b/tf_image_segmentation/utils/inference.py
@@ -1,8 +1,5 @@
 import tensorflow as tf
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 def adapt_network_for_any_size_input(network_definition, multiple):
     """Returns an updated function for network definition that supports input of any size.
     The function creates a new function that is an original function wrapped with

--- a/tf_image_segmentation/utils/tf_records.py
+++ b/tf_image_segmentation/utils/tf_records.py
@@ -9,9 +9,6 @@ import numpy as np
 import skimage.io as io
 import tensorflow as tf
 
-# For comparing tf versions for backwards compatibility
-from packaging import version
-
 # Helper functions for defining tf types
 def _bytes_feature(value):
     return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))

--- a/tf_image_segmentation/utils/tf_records.py
+++ b/tf_image_segmentation/utils/tf_records.py
@@ -157,20 +157,14 @@ def read_tfrecord_and_decode_into_image_annotation_pair_tensors(tfrecord_filenam
     height = tf.cast(features['height'], tf.int32)
     width = tf.cast(features['width'], tf.int32)
     
-    if version.parse(tf.__version__) >= version.parse('1.0.0'):
-        image_shape = tf.stack([height, width, 3])
-    else:
-        image_shape = tf.pack([height, width, 3])
+    image_shape = tf.stack([height, width, 3])
     
     # The last dimension was added because
     # the tf.resize_image_with_crop_or_pad() accepts tensors
     # that have depth. We need resize and crop later.
     # TODO: See if it is necessary and probably remove third
     # dimension
-    if version.parse(tf.__version__) >= version.parse('1.0.0'):
-        annotation_shape = tf.stack([height, width, 1])
-    else:
-        annotation_shape = tf.pack([height, width, 1])
+    annotation_shape = tf.stack([height, width, 1])
     
     image = tf.reshape(image, image_shape)
     annotation = tf.reshape(annotation, annotation_shape)

--- a/tf_image_segmentation/utils/tf_records.py
+++ b/tf_image_segmentation/utils/tf_records.py
@@ -9,6 +9,9 @@ import numpy as np
 import skimage.io as io
 import tensorflow as tf
 
+# For comparing tf versions for backwards compatibility
+from packaging import version
+
 # Helper functions for defining tf types
 def _bytes_feature(value):
     return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
@@ -154,14 +157,20 @@ def read_tfrecord_and_decode_into_image_annotation_pair_tensors(tfrecord_filenam
     height = tf.cast(features['height'], tf.int32)
     width = tf.cast(features['width'], tf.int32)
     
-    image_shape = tf.pack([height, width, 3])
+    if version.parse(tf.__version__) >= version.parse('1.0.0'):
+        image_shape = tf.stack([height, width, 3])
+    else:
+        image_shape = tf.pack([height, width, 3])
     
     # The last dimension was added because
     # the tf.resize_image_with_crop_or_pad() accepts tensors
     # that have depth. We need resize and crop later.
     # TODO: See if it is necessary and probably remove third
     # dimension
-    annotation_shape = tf.pack([height, width, 1])
+    if version.parse(tf.__version__) >= version.parse('1.0.0'):
+        annotation_shape = tf.stack([height, width, 1])
+    else:
+        annotation_shape = tf.pack([height, width, 1])
     
     image = tf.reshape(image, image_shape)
     annotation = tf.reshape(annotation, annotation_shape)

--- a/tf_image_segmentation/utils/upsampling.py
+++ b/tf_image_segmentation/utils/upsampling.py
@@ -36,7 +36,7 @@ def bilinear_upsample_weights(factor, number_of_classes):
     
     upsample_kernel = upsample_filt(filter_size)
     
-    for i in xrange(number_of_classes):
+    for i in range(number_of_classes):
         
         weights[:, :, i, i] = upsample_kernel
     


### PR DESCRIPTION
Fix for #8 based on comments by @vijtad and @zhaozj89.

Add version checks/changes at fail points based on output of
tf_upgrade_tool.py.

Add Python 3.x compatibility.

Unsure if adding forward/backward compatibility like this is the
best approach for future maintainability.  Please advise and/or
feel free to reject PR as appropriate.